### PR TITLE
Use ifa_ifu for associated_address for android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ mod unix {
                         };
 
                         // https://docs.rs/libc/latest/aarch64-unknown-linux-gnu/libc/struct.ifaddrs.html
-                        #[cfg(target_os = "linux")]
+                        #[cfg(any(target_os = "linux", target_os = "android"))]
                         let associated_address = unsafe {
                             ifaddr
                                 .ifa_ifu
@@ -280,7 +280,7 @@ mod unix {
                         };
 
                         // https://docs.rs/libc/latest/aarch64-unknown-openbsd/libc/struct.ifaddrs.html
-                        #[cfg(not(target_os = "linux"))]
+                        #[cfg(not(any(target_os = "linux", target_os = "android")))]
                         let associated_address = unsafe {
                             ifaddr
                                 .ifa_dstaddr


### PR DESCRIPTION
currently it uses ifa_dstaddr for non-linux os but it should be ifa_ifu for android as well