### PR TITLE
Fix Addresses::len documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,8 @@ impl Addresses {
         self.addresses.is_empty()
     }
 
-    /// Returns the number of addresses in the collection.
+    /// Returns the number of address families represented in the collection.
+    /// To count total individual addresses, iterate and sum the slice lengths.
     pub fn len(&self) -> usize {
         self.addresses.len()
     }


### PR DESCRIPTION
Another doc fix for https://github.com/mmastrac/getifaddrs/commit/e55fa21c91e8cb7bdb8898a7d19ea6938f63cf3d

Because `addresses` is now `BTreeMap<AddressFamily, Vec<Address>>`, `len` will count the keys (families), no longer the addresses.